### PR TITLE
Add gsr_value_delim parameter to MaScorer.actor_score method

### DIFF
--- a/src/ExpressScore/main/express_score.py
+++ b/src/ExpressScore/main/express_score.py
@@ -616,20 +616,21 @@ class MaScorer(Scorer):
 
     @staticmethod
     def actor_score(warn_actor, gsr_actor, legit_actors=ACTORS,
-                    wildcards=WILDCARD_ACTORS):
+                    wildcards=WILDCARD_ACTORS, gsr_value_delim=";"):
         """
         Computes the facet score for Actor
         :param warn_actor: Warning value for Actor
         :param gsr_actor: GSR value for Actor, could be a list
         :param legit_actors: Which actors are legal values for submission
         :param wildcards: Which values in the GSR are assumed to match all legit inputs?
+        :param gsr_value_delim: Character that separates actors in a string
         :return: 1 if it matches, 0 if it doesn't.
         """
 
         if warn_actor not in legit_actors:
             _as = 0
         else:
-            _as = Scorer.facet_score(warn_actor, gsr_actor, wildcards)
+            _as = Scorer.facet_score(warn_actor, gsr_actor, wildcards, gsr_value_delim)
 
         return _as
 

--- a/src/ExpressScore/test/test_ma_scoring.py
+++ b/src/ExpressScore/test/test_ma_scoring.py
@@ -542,6 +542,14 @@ class MaScorerTest(unittest.TestCase):
         expected = 1
         result = Scorer.facet_score(warn_value, gsr_value, wildcards)
         self.assertEqual(result, expected)
+        gsr_value = "Ethel;Fred"
+        expected = 1
+        result = Scorer.facet_score(warn_value, gsr_value, wildcards)
+        self.assertEqual(result, expected)
+        gsr_value = "Ethel,Fred"
+        expected = 1
+        result = Scorer.facet_score(warn_value, gsr_value, wildcards, gsr_value_delim=",")
+        self.assertEqual(result, expected)
 
     def test_actor_score(self):
         """
@@ -572,6 +580,16 @@ class MaScorerTest(unittest.TestCase):
         gsr_value = ["Ethel", "Fred"]
         expected = 1
         result = MaScorer.actor_score(warn_value, gsr_value, legits, wildcards)
+        self.assertEqual(result, expected)
+        warn_value = "Fred"
+        gsr_value = "Ethel;Fred"
+        expected = 1
+        result = MaScorer.actor_score(warn_value, gsr_value, legits, wildcards)
+        self.assertEqual(result, expected)
+        warn_value = "Fred"
+        gsr_value = "Ethel,Fred"
+        expected = 1
+        result = MaScorer.actor_score(warn_value, gsr_value, legits, wildcards, gsr_value_delim=",")
         self.assertEqual(result, expected)
         warn_value = "Lucy"
         gsr_value = ["Ethel", "Fred"]


### PR DESCRIPTION
Added test cases for "Actor1;Actor2" and "Actor1,Actor2".